### PR TITLE
add some padding

### DIFF
--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -57,7 +57,8 @@ export default function SiteHeader() {
                 alignItems: 'center', 
                 gap: 'clamp(16px, 3vw, 32px)',
                 flexShrink: 0,
-                marginLeft: 'auto'
+                marginLeft: 'auto',
+		paddingRight: 40,
               }}
             >
               <Link
@@ -162,7 +163,8 @@ export default function SiteHeader() {
               alignItems: 'center', 
               gap: 'clamp(16px, 3vw, 32px)',
               flexShrink: 0,
-              marginLeft: 'auto'
+              marginLeft: 'auto',
+	      paddingRight: 40,
             }}
           >
             <Link


### PR DESCRIPTION
This is the easiest way to resolve your issue, however, it's mostly due to the fact you are using `position: absolute` in a ton of places.

This can be useful, but it means you can't use most of the power of css.

It also seems you have two almost identical html trees in this component, it's likely a better idea to only return one and have optional detail changes inside (otherwise they will diverge over time).